### PR TITLE
Configurable bBrakingFrameTolerated

### DIFF
--- a/Source/PBCharacterMovement/Private/Character/PBPlayerMovement.cpp
+++ b/Source/PBCharacterMovement/Private/Character/PBPlayerMovement.cpp
@@ -91,7 +91,7 @@ UPBPlayerMovement::UPBPlayerMovement()
 	// Start out braking
 	bBrakingWindowElapsed = true;
 	BrakingWindowTimeElapsed = 0;
-	BrakingWindow = 16;
+	BrakingWindow = 15;
 	// Crouching
 	CrouchedHalfHeight = 34.29f;
 	MaxWalkSpeedCrouched = RunSpeed * 0.33333333f;

--- a/Source/PBCharacterMovement/Private/Character/PBPlayerMovement.cpp
+++ b/Source/PBCharacterMovement/Private/Character/PBPlayerMovement.cpp
@@ -189,8 +189,6 @@ void UPBPlayerMovement::TickComponent(float DeltaTime, enum ELevelTick TickType,
 	
 	if (IsMovingOnGround())
 	{
-		/** Fractions of a millisecond is such an infinitesimally small amount of time
-		 * that we can truncate it out for the sake of simplicity. */
 		if (!bBrakingWindowElapsed) BrakingWindowTimeElapsed += DeltaTime * 1000;
 
 		if (BrakingWindowTimeElapsed >= BrakingWindow)
@@ -198,7 +196,6 @@ void UPBPlayerMovement::TickComponent(float DeltaTime, enum ELevelTick TickType,
 			bBrakingWindowElapsed = true;
 			BrakingWindowTimeElapsed = 0;
 		}
-		
 	}
 	else
 	{

--- a/Source/PBCharacterMovement/Private/Character/PBPlayerMovement.cpp
+++ b/Source/PBCharacterMovement/Private/Character/PBPlayerMovement.cpp
@@ -189,6 +189,8 @@ void UPBPlayerMovement::TickComponent(float DeltaTime, enum ELevelTick TickType,
 	
 	if (IsMovingOnGround())
 	{
+		/** Fractions of a millisecond is such an infinitesimally small amount of time
+		 * that we can truncate it out for the sake of simplicity. */
 		if (!bBrakingWindowElapsed) BrakingWindowTimeElapsed += DeltaTime * 1000;
 
 		if (BrakingWindowTimeElapsed >= BrakingWindow)

--- a/Source/PBCharacterMovement/Private/Character/PBPlayerMovement.cpp
+++ b/Source/PBCharacterMovement/Private/Character/PBPlayerMovement.cpp
@@ -199,7 +199,13 @@ void UPBPlayerMovement::TickComponent(float DeltaTime, enum ELevelTick TickType,
 			BrakingWindowTimeElapsed = 0;
 		}
 		
-	} else bBrakingWindowElapsed = false; // don't brake in the air lol
+	}
+	else
+	{
+		bBrakingWindowElapsed = false; // don't brake in the air lol
+		BrakingWindowTimeElapsed = 0;
+		// make sure this is cleared so the window doesn't shrink on subsequent bhops until it expires.
+	}
 	
 	bCrouchFrameTolerated = IsCrouching();
 }

--- a/Source/PBCharacterMovement/Private/Character/PBPlayerMovement.cpp
+++ b/Source/PBCharacterMovement/Private/Character/PBPlayerMovement.cpp
@@ -90,8 +90,8 @@ UPBPlayerMovement::UPBPlayerMovement()
 	SpeedMultMax = SprintSpeed * 2.5f;
 	// Start out braking
 	bBrakingWindowElapsed = true;
-	BrakingWindowTimeElapsed = 0;
-	BrakingWindow = 15;
+	BrakingWindowTimeElapsed = 0.f;
+	BrakingWindow = 15.f;
 	// Crouching
 	CrouchedHalfHeight = 34.29f;
 	MaxWalkSpeedCrouched = RunSpeed * 0.33333333f;

--- a/Source/PBCharacterMovement/Private/Character/PBPlayerMovement.cpp
+++ b/Source/PBCharacterMovement/Private/Character/PBPlayerMovement.cpp
@@ -89,7 +89,9 @@ UPBPlayerMovement::UPBPlayerMovement()
 	SpeedMultMin = SprintSpeed * 1.7f;
 	SpeedMultMax = SprintSpeed * 2.5f;
 	// Start out braking
-	bBrakingFrameTolerated = true;
+	bBrakingWindowElapsed = true;
+	BrakingWindowTimeElapsed = 0;
+	BrakingWindow = 83;
 	// Crouching
 	CrouchedHalfHeight = 34.29f;
 	MaxWalkSpeedCrouched = RunSpeed * 0.33333333f;
@@ -184,8 +186,19 @@ void UPBPlayerMovement::TickComponent(float DeltaTime, enum ELevelTick TickType,
 		ControlRotation.Roll = GetCameraRoll();
 		PBCharacter->GetController()->SetControlRotation(ControlRotation);
 	}
+	
+	if (IsMovingOnGround())
+	{
+		if (!bBrakingWindowElapsed) BrakingWindowTimeElapsed += DeltaTime * 1000;
 
-	bBrakingFrameTolerated = IsMovingOnGround();
+		if (BrakingWindowTimeElapsed >= BrakingWindow)
+		{
+			bBrakingWindowElapsed = true;
+			BrakingWindowTimeElapsed = 0;
+		}
+		
+	} else bBrakingWindowElapsed = false; // don't brake in the air lol
+	
 	bCrouchFrameTolerated = IsCrouching();
 }
 
@@ -680,7 +693,7 @@ void UPBPlayerMovement::PlayMoveSound(const float DeltaTime)
 
 	// Only play sounds if we are moving fast enough on the ground or on a
 	// ladder
-	const bool bPlaySound = (bBrakingFrameTolerated || bOnLadder) && Speed >= RunSpeedThreshold * RunSpeedThreshold;
+	const bool bPlaySound = (bBrakingWindowElapsed || bOnLadder) && Speed >= RunSpeedThreshold * RunSpeedThreshold;
 
 	if (!bPlaySound)
 	{
@@ -1237,7 +1250,7 @@ void UPBPlayerMovement::CalcVelocity(float DeltaTime, float Friction, bool bFlui
 
 	// Apply braking or deceleration
 	const bool bZeroAcceleration = Acceleration.IsNearlyZero();
-	const bool bIsGroundMove = IsMovingOnGround() && bBrakingFrameTolerated;
+	const bool bIsGroundMove = IsMovingOnGround() && bBrakingWindowElapsed;
 
 	// Apply friction
 	if (bIsGroundMove)

--- a/Source/PBCharacterMovement/Private/Character/PBPlayerMovement.cpp
+++ b/Source/PBCharacterMovement/Private/Character/PBPlayerMovement.cpp
@@ -91,7 +91,7 @@ UPBPlayerMovement::UPBPlayerMovement()
 	// Start out braking
 	bBrakingWindowElapsed = true;
 	BrakingWindowTimeElapsed = 0;
-	BrakingWindow = 83;
+	BrakingWindow = 16;
 	// Crouching
 	CrouchedHalfHeight = 34.29f;
 	MaxWalkSpeedCrouched = RunSpeed * 0.33333333f;

--- a/Source/PBCharacterMovement/Public/Character/PBPlayerMovement.h
+++ b/Source/PBCharacterMovement/Public/Character/PBPlayerMovement.h
@@ -68,8 +68,15 @@ protected:
 	UPROPERTY(Category = "Character Movement: Walking", EditAnywhere, BlueprintReadWrite)
 	float MinStepHeight;
 
-	/** If the player has already landed for a frame, and breaking may be applied. */
-	bool bBrakingFrameTolerated;
+	/** Time (in millis) the player has to rejump without applying friction. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Character Movement: Jumping / Falling")
+	int BrakingWindow;
+
+	/* Progress checked against the Braking Window, incremented in millis. */
+	int BrakingWindowTimeElapsed;
+
+	/** If the player has been on the ground past the Braking Window, start braking. */
+	bool bBrakingWindowElapsed;
 
 	/** Wait a frame before crouch speed. */
 	bool bCrouchFrameTolerated = false;
@@ -202,7 +209,7 @@ public:
 
 	bool IsBrakingFrameTolerated() const
 	{
-		return bBrakingFrameTolerated;
+		return bBrakingWindowElapsed;
 	}
 
 	bool IsInCrouch() const

--- a/Source/PBCharacterMovement/Public/Character/PBPlayerMovement.h
+++ b/Source/PBCharacterMovement/Public/Character/PBPlayerMovement.h
@@ -207,7 +207,7 @@ public:
 	/** Toggle no clip */
 	void ToggleNoClip();
 
-	bool IsBrakingFrameTolerated() const
+	bool IsBrakingWindowTolerated() const
 	{
 		return bBrakingWindowElapsed;
 	}

--- a/Source/PBCharacterMovement/Public/Character/PBPlayerMovement.h
+++ b/Source/PBCharacterMovement/Public/Character/PBPlayerMovement.h
@@ -70,10 +70,10 @@ protected:
 
 	/** Time (in millis) the player has to rejump without applying friction. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Character Movement: Jumping / Falling", meta=(DisplayName="Rejump Window", ForceUnits="ms"))
-	int BrakingWindow;
+	float BrakingWindow;
 
 	/* Progress checked against the Braking Window, incremented in millis. */
-	int BrakingWindowTimeElapsed;
+	float BrakingWindowTimeElapsed;
 
 	/** If the player has been on the ground past the Braking Window, start braking. */
 	bool bBrakingWindowElapsed;

--- a/Source/PBCharacterMovement/Public/Character/PBPlayerMovement.h
+++ b/Source/PBCharacterMovement/Public/Character/PBPlayerMovement.h
@@ -69,7 +69,7 @@ protected:
 	float MinStepHeight;
 
 	/** Time (in millis) the player has to rejump without applying friction. */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Character Movement: Jumping / Falling")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Character Movement: Jumping / Falling", meta=(DisplayName="Rejump Window", ForceUnits="ms"))
 	int BrakingWindow;
 
 	/* Progress checked against the Braking Window, incremented in millis. */


### PR DESCRIPTION
Reimplement `bBrakingFrameTolerated`'s logic to be explicitly decoupled from framerate and configurable.

Under the proposed logic, when the player initially lands on the ground, `DeltaTime` is converted to milliseconds and added each frame to a timer that tracks how long they've been on the ground. When this timer reaches the configured braking window, braking can be applied and the timer is zeroed out until the player jumps and lands on the ground again.

The braking window is exposed in Blueprints and defaults to 16 milliseconds, or 1 frame at 60FPS.